### PR TITLE
(#378): allow different keyboard layouts in one hardware type

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -237,6 +237,7 @@ class App extends React.Component {
                   onConnect={this.onKeyboardConnect}
                   onDisconnect={this.onKeyboardDisconnect}
                   titleElement={() => document.querySelector("#page-title")}
+                  connected={this.state.connected}
                 />
                 <Editor
                   path="/editor"

--- a/src/renderer/screens/KeyboardSelect.js
+++ b/src/renderer/screens/KeyboardSelect.js
@@ -148,8 +148,15 @@ class KeyboardSelect extends React.Component {
     return new Promise(resolve => {
       focus
         .find(...Hardware.serial)
-        .then(devices => {
-          const list = this.findNonSerialKeyboards(devices);
+        .then(async devices => {
+          let newDevices;
+          await focus.open(devices[0].comName, devices[0]);
+          let keyboardType = await focus.getKeyboardType();
+          focus.close();
+          newDevices = devices.filter(
+            item => keyboardType.trim() === item.device.info.keyboardType
+          );
+          const list = this.findNonSerialKeyboards(newDevices);
           this.setState({
             loading: false,
             devices: list


### PR DESCRIPTION
This code works with new [Chysalis keyboard API](https://github.com/keyboardio/chrysalis-api)
but can't make a [Pull Request](https://github.com/keyboardio/chrysalis-api/pull/22) (ANSI, ISO packages) yet before fixing [this commit](https://github.com/keyboardio/chrysalis-api/pull/22/commits/cafa064a7a680e3a41c7d4bf5f0508a3b22199c5)
*********

*** also still have a bug with changing keyboards...
...to get the type of hardware - should open focus.. and then close it by `focuse.close()` : there is no third party type of the way.. in this case the port is in open status or on close status...

will fix it soon...